### PR TITLE
[fix_cgo_threads] Add wrapper config

### DIFF
--- a/clienttest/helpers.go
+++ b/clienttest/helpers.go
@@ -70,7 +70,7 @@ func LoadTvc(name string, v AbiVersion) string {
 func NewTestClient() *client.Client {
 	c, err := client.NewClient(client.Config{
 		Network: &client.NetworkConfig{ServerAddress: null.NewString("http://localhost", true)},
-	})
+	}, client.WrapperConfig{MaxCGOConcurrentThreads: 10})
 	if err != nil {
 		panic(err)
 	}

--- a/clienttest/mod_client_test.go
+++ b/clienttest/mod_client_test.go
@@ -14,7 +14,7 @@ func TestModClient(t *testing.T) {
 	a := assert.New(t)
 	c, err := client.NewClient(client.Config{
 		Network: &client.NetworkConfig{ServerAddress: null.NewString("net.ton.dev", true)},
-	})
+	}, client.WrapperConfig{MaxCGOConcurrentThreads: 10})
 	if err == nil {
 		defer c.Close()
 	}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -15,7 +15,7 @@ import (
 func newClient() (*client.Client, error) {
 	return client.NewClient(client.Config{
 		Network: &client.NetworkConfig{ServerAddress: null.NewString("net.ton.dev", true)},
-	})
+	}, client.WrapperConfig{MaxCGOConcurrentThreads: 10})
 }
 
 func printResult(data interface{}) error {


### PR DESCRIPTION
Specify MaxCGOConcurrentThreads as limit to prevent CGO calls
from spawning unlimited system threads when there are a lot of
concurrent requests to wrapper.